### PR TITLE
Fix for AttributeError when initialized with robots=False

### DIFF
--- a/hodor/__init__.py
+++ b/hodor/__init__.py
@@ -58,9 +58,9 @@ class Hodor(object):
         return '{uri.scheme}://{uri.netloc}/'.format(uri=parsed_uri)
 
     def _crawl_delay(self, crawl_delay):
-        expiry, robots = self.robots.fetch('{}robots.txt'.format(self.domain))
-        delay = robots.agent(self.ua).delay
         if self.robots not in EMPTY_VALUES:
+            expiry, robots = self.robots.fetch('{}robots.txt'.format(self.domain))
+            delay = robots.agent(self.ua).delay
             try:
                 crawl_delay = max(filter(partial(is_not, None),
                                          [delay, crawl_delay]))


### PR DESCRIPTION
Hodor gives `AttributeError` when initialized with `robots=False`.
The problem is with `_crawl_delay()` which does not check if `self.robots` exist
before calling `self.robots.fetch`

This patch fixes that